### PR TITLE
Fixed tests

### DIFF
--- a/spec/default/auto_scaling_spec.rb
+++ b/spec/default/auto_scaling_spec.rb
@@ -8,17 +8,17 @@ describe "AutoScaling" do
 
   describe "Auto Scaling Groups" do
     subject { @auto_scaling.groups }
-    it { is_expected have(0).auto_scaling_groups }
+    it { should have(0).auto_scaling_groups }
   end
 
   describe "Launch Configurations" do
     subject { @auto_scaling.launch_configurations }
-    it { is_expected have(0).launch_configurations }
+    it { should have(0).launch_configurations }
   end
 
   describe "Scheduled Actions" do
     subject { @auto_scaling.scheduled_actions }
-    it { is_expected have(0).scheduled_actions }
+    it { should have(0).scheduled_actions }
   end
 
 end

--- a/spec/default/cloud_formation_spec.rb
+++ b/spec/default/cloud_formation_spec.rb
@@ -7,7 +7,7 @@ describe "CloudFormation" do
 
   describe "Stacks" do
     subject { @cloud_formation.stacks }
-    it { is_expected have(0).stacks }
+    it { should have(0).stacks }
   end
 
 end

--- a/spec/default/cloud_front_spec.rb
+++ b/spec/default/cloud_front_spec.rb
@@ -7,7 +7,7 @@ describe "CloudFront" do
 
   describe "Distributions" do
     subject { @cloud_front.client.list_distributions[:items] }
-    it { is_expected have(0).distributions }
+    it { should have(0).distributions }
   end
 
 end

--- a/spec/default/dynamo_db_spec.rb
+++ b/spec/default/dynamo_db_spec.rb
@@ -7,7 +7,7 @@ describe "DynamoDB" do
 
   describe "Tables" do
     subject { @dynamo_db.tables }
-    it { is_expected have(0).tables }
+    it { should have(0).tables }
   end
 
 end

--- a/spec/default/ec2_spec.rb
+++ b/spec/default/ec2_spec.rb
@@ -9,77 +9,77 @@ describe "EC2" do
 
   describe "VPCs" do
     subject { @ec2.vpcs }
-    it { is_expected have(1).vpcs }
+    it { should have(1).vpcs }
   end
 
   describe "Subnets" do
     subject { @ec2.subnets }
-    it { is_expected have(@number_of_az).subnets }
+    it { should have(@number_of_az).subnets }
   end
 
   describe "VPN Gateways" do
     subject { @ec2.vpn_gateways }
-    it { is_expected have(0).vpn_gateways }
+    it { should have(0).vpn_gateways }
   end
 
   describe "Internet Gateways" do
     subject { @ec2.internet_gateways }
-    it { is_expected have(1).internet_gateways }
+    it { should have(1).internet_gateways }
   end
 
   describe "Customer Gateways" do
     subject { @ec2.customer_gateways }
-    it { is_expected have(0).customer_gateways }
+    it { should have(0).customer_gateways }
   end
 
   describe "VPN Connections" do
     subject { @ec2.vpn_connections }
-    it { is_expected have(0).vpn_connections }
+    it { should have(0).vpn_connections }
   end
 
   describe "Network ACLs" do
     subject { @ec2.network_acls }
-    it { is_expected have(1).network_acls }
+    it { should have(1).network_acls }
   end
 
   describe "Route Tables" do
     subject { @ec2.route_tables }
-    it { is_expected have(1).route_tables }
+    it { should have(1).route_tables }
   end
 
   describe "DHCP Optinos" do
     subject { @ec2.dhcp_options }
-    it { is_expected have(1).dhcp_options }
+    it { should have(1).dhcp_options }
   end
 
   describe "Instances" do
     subject { @ec2.instances }
-    it { is_expected have(0).instances }
+    it { should have(0).instances }
   end
 
   describe "Volumes" do
     subject { @ec2.volumes }
-    it { is_expected have(0).volumes }
+    it { should have(0).volumes }
   end
 
   describe "Elastic IPs" do
     subject { @ec2.elastic_ips }
-    it { is_expected have(0).elastic_ips }
+    it { should have(0).elastic_ips }
   end
 
   describe "Key Pairs" do
     subject { @ec2.key_pairs }
-    it { is_expected have(0).key_pairs }
+    it { should have(0).key_pairs }
   end
 
   describe "Snapshots" do
     subject { @ec2.snapshots.with_owner(:self) }
-    it { is_expected have(0).snapshots }
+    it { should have(0).snapshots }
   end
 
   describe "Security Group" do
     subject { @ec2.security_groups }
-    it { is_expected have(1).security_groups }
+    it { should have(1).security_groups }
   end
 
 end

--- a/spec/default/elasti_cache_spec.rb
+++ b/spec/default/elasti_cache_spec.rb
@@ -7,7 +7,7 @@ describe "ElastiCache" do
 
   describe "Clusters" do
     subject { @elasti_cache.client.describe_cache_clusters[:cache_clusters] }
-    it { is_expected have(0).clusters }
+    it { should have(0).clusters }
   end
 
 end

--- a/spec/default/elb_spec.rb
+++ b/spec/default/elb_spec.rb
@@ -7,7 +7,7 @@ describe "ELB" do
 
   describe "Load Balancers" do
     subject { @elb.load_balancers }
-    it { is_expected have(0).load_balancers }
+    it { should have(0).load_balancers }
   end
 
 end

--- a/spec/default/emr_spec.rb
+++ b/spec/default/emr_spec.rb
@@ -7,7 +7,7 @@ describe "EMR" do
 
   describe "Job Flows" do
     subject { @emr.job_flows }
-    it { is_expected have(0).job_flows }
+    it { should have(0).job_flows }
   end
 
 end

--- a/spec/default/rds_spec.rb
+++ b/spec/default/rds_spec.rb
@@ -7,7 +7,7 @@ describe "RDS" do
 
   describe "DB Instances" do
     subject { @rds.db_instances }
-    it { is_expected have(0).db_instances }
+    it { should have(0).db_instances }
   end
 
 end

--- a/spec/default/redshift_spec.rb
+++ b/spec/default/redshift_spec.rb
@@ -7,7 +7,7 @@ describe "Redshift" do
 
   describe "Clusters" do
     subject { @redshift.client.describe_clusters[:clusters] }
-    it { is_expected have(0).clusters }
+    it { should have(0).clusters }
   end
 
 end

--- a/spec/default/route53_spec.rb
+++ b/spec/default/route53_spec.rb
@@ -7,7 +7,7 @@ describe "Route53" do
 
   describe "Hosted Zones" do
     subject { @route53.hosted_zones }
-    it { is_expected have(0).hosted_zones }
+    it { should have(0).hosted_zones }
   end
 
 end

--- a/spec/default/s3_spec.rb
+++ b/spec/default/s3_spec.rb
@@ -7,7 +7,7 @@ describe "S3" do
 
   describe "Buckets" do
     subject { @s3.buckets }
-    it { is_expected have(0).buckets }
+    it { should have(0).buckets }
   end
 
 end

--- a/spec/default/simple_db_spec.rb
+++ b/spec/default/simple_db_spec.rb
@@ -7,7 +7,7 @@ describe "SimpleDB" do
 
   describe "Domains" do
     subject { @simple_db.domains }
-    it { is_expected have(0).domains }
+    it { should have(0).domains }
   end
 
 end

--- a/spec/default/simple_workflow_spec.rb
+++ b/spec/default/simple_workflow_spec.rb
@@ -7,7 +7,7 @@ describe "SimpleWorkflow" do
 
   describe "Domains" do
     subject { @simple_workflow.domains }
-    it { is_expected have(0).domains }
+    it { should have(0).domains }
   end
 
 end

--- a/spec/default/sqs_spec.rb
+++ b/spec/default/sqs_spec.rb
@@ -7,7 +7,7 @@ describe "SQS" do
 
   describe "Queues" do
     subject { @sqs.queues }
-    it { is_expected have(0).queues }
+    it { should have(0).queues }
   end
 
 end

--- a/spec/example/ec2/instance/example-www_spec.rb
+++ b/spec/example/ec2/instance/example-www_spec.rb
@@ -8,14 +8,14 @@ describe "EC2" do
   end
 
   describe "instance" do
-    it { @instance.is_expected_not be_nil }
+    it { @instance.should_not be_nil }
   end
 
   describe "Block devices" do
     before :all do
       @devices = @instance.block_devices
     end
-    it { @devices.count.is_expected == 1 }
+    it { @devices.count.should == 1 }
 
     describe "/dev/sda1" do
       before :all do
@@ -23,30 +23,30 @@ describe "EC2" do
         @volume = @ec2.volumes[@ebs[:volume_id]]
       end
 
-      it { @ebs[:delete_on_termination].is_expected be_true }
-      it { @volume.iops.is_expected be_nil }
-      it { @volume.size.is_expected == 8 }
+      it { @ebs[:delete_on_termination].should be_true }
+      it { @volume.iops.should be_nil }
+      it { @volume.size.should == 8 }
     end
   end
 
   describe "Security Groups" do
-    it { @instance.security_groups.first.name.is_expected == "www" }
+    it { @instance.security_groups.first.name.should == "www" }
   end
 
   describe "Private IP Address" do
-    it { @instance.private_ip_address.is_expected == "192.168.10.10" }
+    it { @instance.private_ip_address.should == "192.168.10.10" }
   end
 
   describe "Public IP Address" do
-    it { @instance.public_ip_address.is_expected == "54.238.176.185" }
+    it { @instance.public_ip_address.should == "54.238.176.185" }
   end
 
   describe "Instance Type" do
-    it { @instance.instance_type.is_expected == "t1.micro" }
+    it { @instance.instance_type.should == "t1.micro" }
   end
 
   describe "AMI Name" do
-    it { @instance.image.name.is_expected == "amzn-ami-pv-2013.03.1.x86_64-ebs" }
+    it { @instance.image.name.should == "amzn-ami-pv-2013.03.1.x86_64-ebs" }
   end
 
 end

--- a/spec/example/ec2/security_group/www_spec.rb
+++ b/spec/example/ec2/security_group/www_spec.rb
@@ -30,19 +30,19 @@ describe "Security Group" do
   end
 
   describe "security_groups" do
-    it { @security_group.is_expected_not be_nil }
+    it { @security_group.should_not be_nil }
   end
 
   describe "vpc?" do
-    it { @security_group.vpc?.is_expected be_true }
+    it { @security_group.vpc?.should be_true }
   end
 
   describe "inbound" do
-    it { @security_group.ip_permissions_list.eql?(@inbound).is_expected be_true }
+    it { @security_group.ip_permissions_list.eql?(@inbound).should be_true }
   end
 
   describe "outbound" do
-    it { @security_group.ip_permissions_list_egress.eql?(@outbound).is_expected be_true }
+    it { @security_group.ip_permissions_list_egress.eql?(@outbound).should be_true }
   end
 
 end


### PR DESCRIPTION
This was a once-over to get rid of argument-length errors. Another pass would be necessary to convert to the new 'expect' syntax for rspec.